### PR TITLE
Increase max_output_size

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -111,6 +111,7 @@
       smtpHost = "localhost";
       extraConfig = ''
         store_uri = ${config.simple-hydra.store_uri}
+        max_output_size = ${ 4 * 1024 * 1024 * 1024 }
       ''; 
     };
 


### PR DESCRIPTION
Job output size seems to be limited:
https://hydra.tylerbenster.com/build/36

found this setting that may help
https://github.com/NixOS/hydra/issues/467
https://github.com/NixOS/hydra/blob/d4b4255dd2aef51db916dfafd78891178534fd56/src/hydra-queue-runner/hydra-queue-runner.cc#L50